### PR TITLE
rclone: disable selfupdate

### DIFF
--- a/rclone/Makefile
+++ b/rclone/Makefile
@@ -68,7 +68,7 @@ define Build/Compile
                 cd $(PKG_BUILD_DIR); \
                 mkdir -p bin; \
                 cd src/$(PKG_GOGET); \
-                CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=$(GOARCH) $(GOARM) GOPATH=$(PKG_BUILD_DIR) $(GOROOT)/bin/go build -ldflags="-s -w" -x -v; \
+                CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=$(GOARCH) $(GOARM) GOPATH=$(PKG_BUILD_DIR) $(GOROOT)/bin/go build -ldflags="-s -w" -tags=noselfupdate -x -v; \
                 cp rclone $(PKG_BUILD_DIR)/bin; \
                 chmod -R +w $(PKG_BUILD_DIR)/pkg; \
         )


### PR DESCRIPTION
I think it makes sense to build rclone without the `rclone selfupdate` command. To avoid replacing the custom package manager installed variant with a plain official release. To "ensure" updates are done via the package manager instead. At least for the "nohf" (GOARM=5) variant, since upstream rclone does not publish any such builds and running `rclone selfupdate` will actually install a GOARM=6 build - which will probably not run.