### PR TITLE
Fix Tailscale crashes on Asus routers, add `statedir` launch argument

### DIFF
--- a/tailscale/files/S06tailscaled
+++ b/tailscale/files/S06tailscaled
@@ -2,8 +2,8 @@
 
 ENABLED=yes
 PROCS=tailscaled
-ARGS="--state=/opt/var/tailscaled.state"
-PREARGS=""
+ARGS="--state=/opt/var/tailscaled.state --statedir=/opt/var/lib/tailscale"
+PREARGS="nohup"
 DESC=$PROCS
 PATH=/opt/sbin:/opt/bin:/opt/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 


### PR DESCRIPTION
Fix: https://github.com/Entware/Entware/issues/990, https://github.com/Entware/Entware/issues/1040

cc: @The-BB @zyxmon 