### PR TITLE
mihomo: new package

### DIFF
--- a/mihomo/Makefile
+++ b/mihomo/Makefile
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 Entware
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mihomo
+PKG_VERSION:=1.19.27
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/MetaCubeX/mihomo
+PKG_MIRROR_HASH:=874e0c44d72d5c017b3e6904542502b7645bdc7fb55a924b2ee608d9e52268d8
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Entware team, https://entware.net
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/golang.mk
+
+define Package/mihomo/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Mihomo (MetaCubeX) universal proxy
+  URL:=https://wiki.metacubex.one
+  EXTRA_DEPENDS:=ca-bundle
+endef
+
+define Package/mihomo
+  $(call Package/mihomo/Default)
+  VARIANT:=hf
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/mihomo_nohf
+  $(call Package/mihomo/Default)
+  VARIANT:=nohf
+  DEPENDS:=@arm
+endef
+
+define Package/mihomo/description
+  Mihomo is a rule-based tunnel that supports multiple protocols, including
+  HTTP, HTTPS, SOCKS5, Shadowsocks, VMess and so on.
+endef
+
+Package/mihomo_nohf/description=$(Package/mihomo/description)
+
+define Package/mihomo/conffiles
+/opt/etc/mihomo/config.yaml
+endef
+
+Package/mihomo_nohf/conffiles=$(Package/mihomo/conffiles)
+
+XIMPORTPATH:=$(call tolower,$(XIMPORTPATH))
+
+GO_LDFLAGS += \
+  -X '$(XIMPORTPATH)/constant.Version=$(PKG_VERSION)' \
+  -X '$(XIMPORTPATH)/constant.BuildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ --date=@$(SOURCE_DATE_EPOCH))'
+
+GO_TARGET:=./
+GO_TAGS:=with_gvisor
+
+define Package/mihomo/install
+	$(INSTALL_DIR) $(1)/opt/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/mihomo $(1)/opt/bin/mihomo
+	$(INSTALL_DIR) $(1)/opt/etc/init.d
+	$(INSTALL_BIN) ./files/S99mihomo $(1)/opt/etc/init.d
+	$(INSTALL_DIR) $(1)/opt/etc/mihomo
+	$(INSTALL_CONF) ./files/config.yaml $(1)/opt/etc/mihomo
+endef
+
+Package/mihomo_nohf/install=$(Package/mihomo/install)
+
+$(eval $(call BuildPackage,mihomo))
+$(eval $(call BuildPackage,mihomo_nohf))

--- a/mihomo/files/S99mihomo
+++ b/mihomo/files/S99mihomo
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+ENABLED=yes
+PROCS=mihomo
+ARGS="-d /opt/etc/$PROCS"
+PREARGS=""
+DESC=$PROCS
+PATH=/opt/sbin:/opt/bin:/opt/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+. /opt/etc/init.d/rc.func

--- a/mihomo/files/config.yaml
+++ b/mihomo/files/config.yaml
@@ -1,0 +1,134 @@
+# Config file of Mihomo. This file follows standard YAML format, with comments support.
+# Read our manual for more detail at https://wiki.metacubex.one/en/config/
+
+# HTTP + SOCKS mixed proxy.
+mixed-port: 7890
+
+# Do not expose proxy to LAN by default.
+# Change to true only if you really want other devices to use this instance.
+allow-lan: false
+bind-address: 127.0.0.1
+
+mode: rule
+log-level: info
+ipv6: true
+
+# Useful for dashboards and API clients.
+# external-controller: 0.0.0.0:9090
+# secret: "change-me"
+
+# Optional web UI. mihomo can download it automatically.
+# external-ui: ui
+# external-ui-url: "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip"
+
+# Store selected proxy groups and fake-ip cache.
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+# Better latency display and connection behavior.
+unified-delay: true
+tcp-concurrent: true
+
+# GEO data mode for GEOSITE/GEOIP rules.
+# geodata-mode: true
+# geo-auto-update: true
+# geo-update-interval: 24
+#
+# geox-url:
+#   geoip: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.dat"
+#   geosite: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+#   mmdb: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb"
+#   asn: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+
+# Helps route TLS/HTTP connections by domain when possible.
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+    QUIC:
+      ports:
+        - 443
+        - 8443
+  skip-domain:
+    - "+.lan"
+    - "+.local"
+    - "+.localdomain"
+    - "+.push.apple.com"
+
+# DNS
+dns:
+  enable: true
+  listen: 127.0.0.1:1053
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  fake-ip-filter:
+    - "*.lan"
+    - "*.local"
+    - "*.localdomain"
+    - "localhost"
+    - "+.msftconnecttest.com"
+    - "+.msftncsi.com"
+    - "+.pool.ntp.org"
+    - "time.*.com"
+    - "time.*.gov"
+    - "time.*.edu"
+    - "time.*.apple.com"
+
+  default-nameserver:
+    - 1.1.1.1
+    - 8.8.8.8
+
+  # Used to resolve proxy server domains.
+  proxy-server-nameserver:
+    - https://1.1.1.1/dns-query
+    - https://8.8.8.8/dns-query
+
+  nameserver:
+    - https://1.1.1.1/dns-query
+    - https://8.8.8.8/dns-query
+
+  fallback:
+    - tls://1.0.0.1
+    - tls://8.8.4.4
+
+# Proxies
+proxies:
+  # Example VLESS + TCP + Reality.
+  # Replace all placeholder values.
+  # - name: example-vless-reality
+  #   type: vless
+  #   server: example.com
+  #   port: 443
+  #   uuid: 00000000-0000-0000-0000-000000000000
+  #   udp: true
+  #
+  #   tls: true
+  #   network: tcp
+  #   servername: www.example.com
+  #   flow: xtls-rprx-vision
+  #   packet-encoding: xudp
+  #   client-fingerprint: chrome
+  #   skip-cert-verify: false
+  #
+  #   reality-opts:
+  #     public-key: "REPLACE_WITH_REALITY_PUBLIC_KEY"
+  #     short-id: "REPLACE_WITH_SHORT_ID"
+
+# Proxy group
+proxy-groups:
+  - name: GLOBAL
+    type: select
+    proxies:
+      # - example-vless-reality
+      - DIRECT
+      - REJECT


### PR DESCRIPTION
Mihomo (MetaCubeX) universal proxy

Based on PR https://github.com/Entware/entware-go/pull/11

## 📦 Package Details

**Description:**
Mihomo is a rule-based tunnel that supports multiple protocols, including HTTP, HTTPS, SOCKS5, Shadowsocks, VMess and so on.

## 🧪 Run Testing Details

- **Entware Target: aarch64-3.10 / armv7-3.2_nohf**
- **Entware Device: Keenetic KN-1012 (Keenetic OS) / Asus RT-AC68U C1 (DD-WRT)**
